### PR TITLE
Move `test` to `dev_dependencies`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   source_span: ^1.8.1
   glob: ^2.0.2
   yaml: ^3.1.0
-  test: ^1.16.8
 
 dev_dependencies:
   lints: ^1.0.1
   mocktail: ^0.2.0
+  test: ^1.16.8


### PR DESCRIPTION
This PR moves `test` package, that seems to be only used in `test`, to `dev_dependencies` to solve potential version conflict issues on the consumers' ends.
