### PR TITLE
Rollback `test` and Loosen `analyzer` version spec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   source_span: ^1.8.1
   glob: ^2.0.2
   yaml: ^3.1.0
+  test: ^1.16.8
 
 dev_dependencies:
   lints: ^1.0.1
   mocktail: ^0.2.0
-  test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
-  analyzer: ^2.7.0
+  analyzer: ">=2.7.0 <6.0.0"
   analyzer_plugin: ^0.8.0
   args: ^2.3.0
   path: ^1.8.0


### PR DESCRIPTION
This PR reverts https://github.com/hisaichi5518/dart-linting/pull/23 and loosen `analyzer` version instead.
`test` library was actually used in the source code (my bad..😓)

I originally wanted to get rid of `test` because it depends on `test_core` which depends on `analyzer` which can conflict with the one in the SDK we use, and it seemed to be not used in the codebase, which was negative..

There are two ways to solve this:

1. Get rid of `test` and only use `test_api` package
This is the technique `flutter_test` uses. 
However `test_api` is not for common use as described [here](https://github.com/dart-lang/test/blob/b82fc0b5c11fcfe4e636caef6b869f1a8cd4a803/pkgs/test_api/lib/test_api.dart).
2. Put back `test` and loosen related packages' version specs

I chose option 2 because `test_api` is not for general use and can break easily. Just loosing the `analyzer` for now seems to be more straightforward.