### PR TITLE
Loosen analyzer_plugin's version specifier

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ">=2.7.0 <6.0.0"
-  analyzer_plugin: ^0.8.0
+  analyzer_plugin: ">=0.8.0 <1.0.0"
   args: ^2.3.0
   path: ^1.8.0
   source_span: ^1.8.1


### PR DESCRIPTION
As titled, this PR loosens the version specifier of `analyzer_plugin`.

Ref: https://github.com/hisaichi5518/dart-linting/pull/25

The same kind of issue existed around `analyzer_plugin`.
Please note that, `^0.8.0` only passes with `0.8.x`, not `0.9+` as it is still "pre-release" in semantic version and minor upgrades are considered to have breaking changes.